### PR TITLE
Write can be called multiple times, so adding a way to prevent writing headers

### DIFF
--- a/src/FlatMapper/FlatFile.cs
+++ b/src/FlatMapper/FlatFile.cs
@@ -33,12 +33,15 @@ namespace FlatMapper
 
         private readonly System.Text.Encoding encoding;
 
+        private bool _writeHeaders;
+
         public FlatFile(Layout<T> layout, Stream innerStream, System.Text.Encoding encoding, Func<ParserErrorInfo, Exception, bool> handleEntryReadError)
         {
             this.layout = layout;
             this.innerStream = innerStream;
             this.handleEntryReadError = handleEntryReadError;
             this.encoding = encoding;
+            _writeHeaders = true;
         }
 
         public FlatFile(Layout<T> layout, Stream innerStream, Func<ParserErrorInfo, Exception, bool> handleEntryReadError)
@@ -95,9 +98,13 @@ namespace FlatMapper
 
         public void Write(IEnumerable<T> entries)
         {
-            //we're not disposng the StramWriter because it will dispose the inner stream
+            //we're not disposing the StreamWriter because it will dispose the inner stream
             var writer = new StreamWriter(this.innerStream, encoding);
-            WriteHeaders(writer);
+            if(_writeHeaders)
+            {
+                WriteHeaders(writer);
+            }
+            
             foreach (var entry in entries)
             {
                 var line = layout.BuildLine(entry);
@@ -113,6 +120,7 @@ namespace FlatMapper
                 var line = layout.BuildHeaderLine();
                 writer.WriteLine(line);
             }
+            _writeHeaders = false;
         }
     }
 }

--- a/src/FlatMapper/FlatFile.cs
+++ b/src/FlatMapper/FlatFile.cs
@@ -33,7 +33,7 @@ namespace FlatMapper
 
         private readonly System.Text.Encoding encoding;
 
-        private bool _writeHeaders;
+        private bool writeHeaders;
 
         public FlatFile(Layout<T> layout, Stream innerStream, System.Text.Encoding encoding, Func<ParserErrorInfo, Exception, bool> handleEntryReadError)
         {
@@ -41,11 +41,11 @@ namespace FlatMapper
             this.innerStream = innerStream;
             this.handleEntryReadError = handleEntryReadError;
             this.encoding = encoding;
-            _writeHeaders = true;
+            writeHeaders = true;
         }
 
         public FlatFile(Layout<T> layout, Stream innerStream, Func<ParserErrorInfo, Exception, bool> handleEntryReadError)
-            :this(layout, innerStream, System.Text.Encoding.UTF8, handleEntryReadError)
+            : this(layout, innerStream, System.Text.Encoding.UTF8, handleEntryReadError)
         {
         }
 
@@ -100,11 +100,9 @@ namespace FlatMapper
         {
             //we're not disposing the StreamWriter because it will dispose the inner stream
             var writer = new StreamWriter(this.innerStream, encoding);
-            if(_writeHeaders)
-            {
-                WriteHeaders(writer);
-            }
-            
+
+            WriteHeaders(writer);
+
             foreach (var entry in entries)
             {
                 var line = layout.BuildLine(entry);
@@ -115,12 +113,15 @@ namespace FlatMapper
 
         private void WriteHeaders(StreamWriter writer)
         {
-            for (var i = 0; i < layout.HeaderLinesCount; i++)
+            if (writeHeaders)
             {
-                var line = layout.BuildHeaderLine();
-                writer.WriteLine(line);
+                for (var i = 0; i < layout.HeaderLinesCount; i++)
+                {
+                    var line = layout.BuildHeaderLine();
+                    writer.WriteLine(line);
+                }
+                writeHeaders = false;
             }
-            _writeHeaders = false;
         }
     }
 }


### PR DESCRIPTION

For example, you can be chunk reading documents from an Elastic Search cluster, and writing as you process them.